### PR TITLE
docs: align Chinese README with updated English guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,220 +1,318 @@
 # Go SDK
 
+ABetterChoice Go SDK for server-side experiment assignment, feature flag evaluation, remote config lookup,
+and exposure reporting.
+
 ## Supported platforms
 
-The Golang SDK is compatible with the following platforms:
-
 - Linux
-- MacOS
+- macOS
 - Windows
 
-## Getting Started
+## Prerequisites
 
-If you haven't already, please follow the [doc](https://docs.abetterchoice.ai/guide/getting-started/create-project) to create a ABetterChoice project and some experiments. While you can choose to bypass this step for now, please note that you may require the project ID and the names of the experiment layers in subsequent sections.
+- Go 1.17+
+- A project created in ABetterChoice console
+- `ProjectID` and `SecretKey`
+
+Create project and experiment references:
+- [Create Project](https://docs.abetterchoice.ai/guide/getting-started/create-project)
+- [Create Experiment](https://docs.abetterchoice.ai/guide/features/create-experiment)
+- [Feature Flags](https://docs.abetterchoice.ai/guide/features/feature-flags)
 
 ## Installation
 
-In order to use Golang SDK, you need to install the SDK by `go get` CLI, which requires Go 1.17 or higher.
-
-```
+```bash
 go get github.com/abetterchoice/go-sdk
 ```
 
-## SDK Initialization
-
-After installing the SDK, it's necessary to initialize it. The Init function requires three parameters:
-
-1. The first parameter, as per Golang convention, is context.
-2. The second parameter allows for the input of one or more project IDs.
-3. The third parameter is of the type InitOption, offering flexible initialization settings. Currently, only the secret key is required. You can locate this under the API key section within the settings tab.
+## Quick Start (recommended)
 
 ```go
-// Package main ...
 package main
 
 import (
- "context"
- abc "github.com/abetterchoice/go-sdk"
- "log"
+    "context"
+    "log"
+
+    abc "github.com/abetterchoice/go-sdk"
 )
 
-abc.Init(context.TODO(), []string{"{{.ProjectID}}"}, abc.WithSecretKey("{{.SecretKey}}"))
+func main() {
+    ctx := context.Background()
+    projectID := "YOUR_PROJECT_ID"
+    secretKey := "YOUR_SECRET_KEY"
+    unitID := "YOUR_UNIT_ID"
+
+    // Initialize once per process.
+    err := abc.Init(ctx, []string{projectID}, abc.WithSecretKey(secretKey))
+    if err != nil {
+        log.Fatalf("abc.Init failed: %v", err)
+    }
+    defer abc.Release()
+
+    // Build user context for all evaluations.
+    userCtx := abc.NewUserContext(unitID, abc.WithTagKV("region", "sea"))
+
+    // 1) Recommended API: fetch by globally unique variant key.
+    value, err := userCtx.GetValueByVariantKey(ctx, projectID, "drop_rate")
+    if err != nil {
+        log.Printf("GetValueByVariantKey failed: %v", err)
+    } else {
+        dropRate := value.GetFloat64WithDefault(0.05)
+        log.Printf("drop_rate=%v", dropRate)
+    }
+
+    // 2) Layer-based experiment lookup.
+    exp, err := userCtx.GetExperiment(ctx, projectID, "matchmaking_layer")
+    if err != nil {
+        log.Printf("GetExperiment failed: %v", err)
+    } else if exp != nil {
+        mmrWindow := exp.GetInt64WithDefault("mmr_window", 100)
+        log.Printf("mmr_window=%d", mmrWindow)
+    }
+
+    // 3) Feature flag lookup.
+    ff, err := userCtx.GetFeatureFlag(ctx, projectID, "new_shop")
+    if err != nil {
+        log.Printf("GetFeatureFlag failed: %v", err)
+    } else if ff != nil && ff.MustGetBool() {
+        log.Printf("new_shop enabled")
+    }
+}
 ```
 
-*Advanced: This section can be skipped initially and revisited later when needed*
-InitOption provides additional initialization configurations. For more details, please refer to the InitOption implementation. Apart from the secret key used in the preceding code, another commonly used option is to disable exposure logging. By default, the ABC SDK logs exposures (essentially, records of a specific experiment unit being exposed to your experiment) automatically when the `getExperiment` API is called. However, in certain scenarios, this might result in excessive unexpected exposure logs, potentially diluting your results.
-To prevent this, you can fetch the experiment result without logging exposures when calling the `getExperiment` API, and log the exposure later at a more appropriate point. By setting `WithDisableReport(true)`, exposure logging will be globally disabled. We also provide a method to disable exposure logging at the individual API level, which will be explained later in this document.
+## API selection guide
+
+| Scenario | API | Why |
+| --- | --- | --- |
+| Remote parameter lookup by parameter key | `GetValueByVariantKey` | Decouples business code from layer names; supports experiment-first with fallback behavior. |
+| Need full assignment for a known layer | `GetExperiment` | Returns group details and layer-level parameter access. |
+| Need all assigned layers in a project | `GetExperiments` | Batch retrieval for downstream forwarding or diagnostic scenarios. |
+| Need all remote config snapshots (non-experiment path) | `GetAllRemoteConfigs` | Reads all remote-config keys from local cache in one call. |
+| Simple on/off feature control | `GetFeatureFlag` | Boolean-first feature gating with typed getters. |
+
+## Initialization and lifecycle
+
+### `Init(ctx, projectIDList, opts...)`
+
+`Init` performs network fetches and local cache initialization. Call once at process startup.
+
+Key options:
+
+- `WithSecretKey(secretKey)` (required)
+- `WithEnvType(envType)` (optional, default production)
+- `WithDisableReport(true|false)` (optional, global exposure reporting switch)
+- `WithRegionCode(regionCode)` (optional, region-aware config delivery)
+- `WithRegisterCacheClient(...)` / `WithRegisterDMPClient(...)` / `WithRegisterMetricsPlugin(...)` for advanced integration
+
+Example:
 
 ```go
-abc.Init(context.TODO(), []string{"{{.ProjectID}}"}, abc.WithSecretKey("{{.SecretKey}}"), abc.WithDisableReport(true))
+err := abc.Init(
+    context.Background(),
+    []string{"YOUR_PROJECT_ID"},
+    abc.WithSecretKey("YOUR_SECRET_KEY"),
+    abc.WithDisableReport(false),
+)
 ```
 
-*Advanced: Multi-region access*
-ABC is deployed in multiple regions. The SDK targets the global (NA) endpoint by default; if your project is provisioned in the Singapore (SG) region, register the SG endpoint **before** `Init`. Use the SecretKey issued by that region.
+### `Release()`
+
+Call `Release()` on graceful shutdown to reset in-memory state.
+
+## User context and attribution
+
+Build user context with `NewUserContext(unitID, opts...)`.
+
+Common attribution options:
+
+- `WithTags(map[string][]string)`
+- `WithTagKV(key, value)`
+- `WithDecisionID(decisionID)`
+- `WithNewUnitID(newUnitID)` / `WithNewDecisionID(newDecisionID)` for migration scenarios
+- `WithExpandedData(map[string]string)` to enrich exposure logs
+
+Example:
 
 ```go
-import "github.com/abetterchoice/go-sdk/env"
-
-_ = env.RegisterAddr(env.TypePrd, "https://openapi.sg.abetterchoice.ai")
-abc.Init(context.TODO(), []string{"{{.ProjectID}}"},
-    abc.WithEnvType(env.TypePrd),
-    abc.WithSecretKey("{{.SecretKey}}"))
+userCtx := abc.NewUserContext(
+    "player_1001",
+    abc.WithTagKV("channel", "appstore"),
+    abc.WithTagKV("server_id", "s1"),
+)
 ```
 
-## Checking feature flags
+## Evaluation APIs
 
-In this section, we will guide you through the process of retrieving the value of a feature flag. If you haven't already done so, please first follow our [documentation](https://docs.abetterchoice.ai/guide/features/feature-flags) to create one.
-Assuming we have already created a new feature flag named `new_feature_flag` under the project `project_id`, and its value type is Boolean, we can fetch the value in the following manner:
+### Get feature flag
 
 ```go
-abcUserContext, err := abc.NewUserContext("{{.UnitID}}")
-featureFlag, err = abcUserContext.GetFeatureFlag(context.TODO(), "project_id", "new_feature_flag")
-flagValue = featureFlag.MustGetBool()
+userCtx := abc.NewUserContext("{{.UnitID}}")
+featureFlag, err := userCtx.GetFeatureFlag(context.TODO(), "project_id", "new_feature_flag")
+if err == nil && featureFlag != nil {
+    flagValue := featureFlag.MustGetBool()
+    _ = flagValue
+}
 ```
 
-## Getting All Remote Configurations
+### Get experiment by layer key
 
-If you only need a snapshot of every remote configuration value for a project, call `GetAllRemoteConfigs`. It returns the locally cached value of every **non-experiment** remote-config key with its default value.
+```go
+userCtx := abc.NewUserContext("{{.UnitID}}")
+experiment, err := userCtx.GetExperiment(context.TODO(), "project_id", "abc_layer_name")
+if err == nil && experiment != nil {
+    shouldShowBanner := experiment.GetBoolWithDefault("should_show_banner", false)
+    _ = shouldShowBanner
+}
+```
+
+### Get value by variant key
+
+`GetValueByVariantKey` resolves a globally unique parameter key with this order:
+
+1. If the key belongs to one or more experiment layers, traverse layers by each layer's earliest experiment ID (ascending).
+2. Return the first audience-matched non-default group.
+3. If no layer matches a non-default group, fallback to config lookup (`GetRemoteConfig` path).
+
+```go
+userCtx := abc.NewUserContext("{{.UnitID}}")
+result, err := userCtx.GetValueByVariantKey(context.TODO(), "project_id", "should_show_banner")
+if err == nil && result != nil {
+    shouldShowBanner := result.GetBoolWithDefault(false)
+    _ = shouldShowBanner
+
+    // Detail fields help reporting and debugging:
+    // LayerKey / ExperimentKey / ExperimentID / GroupKey / VariantID / ConfigKey
+    _ = result.Detail
+}
+```
+
+### Get all experiments in a project
+
+```go
+userCtx := abc.NewUserContext("{{.UnitID}}")
+experiments, err := userCtx.GetExperiments(context.TODO(), "project_id", abc.WithAutomatic(false))
+if err == nil && experiments != nil {
+    _ = experiments
+}
+```
+
+### Get all remote configs in a project
 
 ```go
 configs, err := abc.GetAllRemoteConfigs("project_id")
 if err == nil {
     for key, value := range configs {
-        log.Infof("%s = %s", key, value.String())
+        _ = key
+        _ = value.String()
     }
 }
 ```
 
-## Getting experiments and logging Exposures
+## Exposure strategy
 
-In this section, we will guide you to create a new experiment and fetch the experiment assignments via our experiment fetching APIs provided by our SDK.
+By default, experiment/config/flag retrieval logs exposure automatically.
 
+Use manual exposure if you prefetch values but only want to report when users actually see the feature.
 
-| Term       | Meaning                                                                                                                                                                                                                  |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| UnitID     | A unit ID can be a user ID, a session ID or a machine ID. The ABC SDK assigns a unit ID to the same group consistantly.                                                                                                  |
-| Layer      | A layer usually represent 100% of the units that you can run experiment in your product, it can be further splited into one or more experiments, the traffic of the experiments under same layer are mutually exclusive. |
-| Experiment | An experiment can take up to 100% of the layer traffic, it will further contain two or more experiment groups.                                                                                                           |
-| Group      | Units within one experiment will be split into two or more groups, e.g. control and treatment, they will be compared against each other.                                                                                 |
-| Parameter  | These are the values binded to a particular layer. Experiments under the same layer can share the same parameters with each other.                                                                                       |
-
-
-### 1. Creating a New Experiment
-
-If you haven't done so already, please navigate to the console and create a new experiment by following our documentation on [how to create an experiment](https://docs.abetterchoice.ai/guide/features/create-experiment).
-
-### 2. Retrieving Experiment Assignments
-
-Assume that in step 1, under the project `project_id`, we have already created an experiment with the layer name `abc_layer_name`. Within this layer, there is a parameter named `should_show_banner` of Boolean type. Please note that in our basic version, the layer name defaults to the experiment name. However, if you create new experiments under the same layer, you will need to find the layer name on the experiment page.
-Currently, we offer three methods to fetch the traffic assignment for a specific unit id. All these APIs require you to establish a user context that encapsulates the unit ID.
+### Disable auto exposure at API level
 
 ```go
-abcUserContext, err := abc.NewUserContext("{{.UnitID}}")
-```
-
-#### a. Retrieve Experiment by Layer Key
-
-The first method involves obtaining the experiment assignment by the layer key and fetching the parameters within the layer using the strong type APIs. This is useful when you have multiple parameters within the layer/experiment. This API will automatically provide the correct result when there are multiple experiments under the same layer, as the unit will and can only fall into one of them. An additional advantage of this method is that it allows you to iterate through the experiments quickly by deallocating the old experiment and creating new ones under the same layer without modifying the code.
-
-```go
-experiment, err := abcUserContext.GetExperiment(context.TODO(), "project_id", "abc_layer_name")
-if err == nil {
-	shouldShowBanner := experiment.GetBoolWithDefault("should_show_banner", false)
+experiments, err := userCtx.GetExperiments(context.TODO(), "project_id", abc.WithAutomatic(false))
+if err == nil && experiments != nil {
+    _ = abc.LogExperimentsExposure(context.TODO(), "project_id", experiments)
 }
 ```
 
-#### b. Retrieve Experiment by Parameter Key
+### Manual exposure APIs
 
-This method is similar to the previous one, with the only difference being that instead of fetching by layer name, we retrieve the result by parameter name, which is unique within the same project. We are planning to introduce features that may allow users to move the parameter from one layer to another (e.g., launcher layer), and this API will be useful in handling such cases.
+- `LogExperimentExposure(ctx, projectID, experimentResult)`
+- `LogExperimentsExposure(ctx, projectID, experimentList)`
+- `LogFeatureFlagExposure(ctx, projectID, featureFlag)`
+- `LogRemoteConfigExposure(ctx, projectID, configResult)`
 
-When the same parameter key is exposed by multiple layers, the SDK ranks those layers by the smallest experiment ID each layer owns (i.e. the creation time of every layer's earliest experiment), then walks them in that order: it returns the first one whose audience matches a non-default group, falling back to the first matched default group. The call no longer errors out in the multi-layer case.
-
-```go
-result, err := abcUserContext.GetValueByVariantKey(context.TODO(), "project_id", "should_show_banner")
-if err == nil {
-    shouldShowBanner := result.GetBoolWithDefault(false)
-    // result.Detail also carries LayerKey / ExperimentKey / ExperimentID / GroupKey / VariantID for reporting.
-}
-```
-
-#### c. Retrieve All Experiment Assignments Under the Project
-
-In some cases, users may need to fetch all experiment assignment results under the same project. To accommodate this, we also provide a batch API, which will return a map linking the experiment layer name to the experiment assignment of the unit specific to that layer. As mentioned earlier, this could lead to dilution problems, so caution is advised when using this API. Depending on your use case, you might consider disabling exposure logging via the opts parameter as shown below. You can use the exposure logging API to manually log the exposure later.
+### Disable exposure globally
 
 ```go
-experiments, err := abcUserContext.GetExperiments(context.TODO(), "project_id", abc.WithAutomatic(false))
-```
-
-### 3. Logging Exposure Data
-
-When retrieving the experiment assignments as described above, you have the option to disable exposure logging to avoid exposure dilution. You can manually log the exposure later at an appropriate time:
-
-```go
-abc.LogExperimentExposure(context.TODO(), "{{.ProjectID}}", experiment)
-```
-
-### 4. Complete code example
-
-Complete code example
-
-```go
-// Package main TODO
-package main
-
-import (
-  "context"
-
-  abc "github.com/abetterchoice/go-sdk"
-  "github.com/abetterchoice/go-sdk/env"
-  "github.com/abetterchoice/go-sdk/plugin/log"
+err := abc.Init(
+    context.Background(),
+    []string{"YOUR_PROJECT_ID"},
+    abc.WithSecretKey("YOUR_SECRET_KEY"),
+    abc.WithDisableReport(true),
 )
-
-func main() {
-  defer abc.Release()
-  projectID := "6666"
-  // Initialize the SDK, and you only need do this once
-  err := abc.Init(context.TODO(), []string{projectID},
-  	abc.WithEnvType(env.TypePrd),
- 	abc.WithSecretKey("{{.SecretKey}}"))
-  if err != nil {
-    log.Errorf("Init fail:%v", err)
-    return
-  }
-
-  // Snapshot of every remote config (no audience / exposure logic).
-  configs, _ := abc.GetAllRemoteConfigs(projectID)
-  for k, v := range configs {
-    log.Infof("remote_config %s = %s", k, v.String())
-  }
-
-  abcUserContext := abc.NewUserContext("unitID_demo")
-
-  // a. Retrieve experiment by layer key; disable auto-exposure to log it manually later.
-  experiment, err := abcUserContext.GetExperiment(context.TODO(), projectID, "abc_layer_name", abc.WithAutomatic(false))
-  if err != nil {
-    log.Errorf("GetExperiment fail:%v", err)
-    return
-  }
-  log.Infof("should_show_banner=%v", experiment.GetBoolWithDefault("should_show_banner", false))
-  _ = abc.LogExperimentExposure(context.TODO(), projectID, experiment)
-
-  // b. Retrieve experiment by parameter key.
-  if result, err := abcUserContext.GetValueByVariantKey(context.TODO(), projectID, "should_show_banner"); err == nil {
-    log.Infof("variant=%v layer=%s expID=%d",
-      result.GetBoolWithDefault(false), result.Detail.LayerKey, result.Detail.ExperimentID)
-  }
-
-  // c. Batch fetch all experiments under the project.
-  if experiments, err := abcUserContext.GetExperiments(context.TODO(), projectID, abc.WithAutomatic(false)); err == nil {
-    for layerKey := range experiments.Data {
-      log.Infof("hit layer=%s", layerKey)
-    }
-  }
-
-  // Feature flag
-  if featureFlag, err := abcUserContext.GetFeatureFlag(context.TODO(), projectID, "new_feature_flag"); err == nil {
-    log.Infof("the feature flag value is %v", featureFlag.MustGetBool())
-  }
-}
 ```
+
+## Advanced options
+
+### Experiment options
+
+Use on `GetExperiment(s)` and `GetValueByVariantKey`:
+
+- `WithLayerKey(layerKey)` / `WithLayerKeyList(layerKeys)`
+- `WithSceneID(sceneID)` / `WithSceneIDList(sceneIDs)`
+- `WithAutomatic(isAutomatic)`
+- `WithIsPreparedDMPTag(isPreparedDMPTag)`
+- `WithIsDisableDMP(isDisableDMP)`
+
+### Config options
+
+Config APIs share the same option type:
+
+- `WithIsPreparedDMPTagConfigOpt(...)`
+- `WithIsDisableDMPConfigOpt(...)`
+
+### Multi-project registration
+
+Register additional projects after init:
+
+```go
+err := abc.RegisterProjectIDs(context.Background(), []string{"PROJECT_B", "PROJECT_C"})
+```
+
+## Troubleshooting
+
+### 1) `Init` failed
+
+- Verify `SecretKey` and `ProjectID`.
+- Verify network access to backend services.
+- If using custom environment, confirm `env.RegisterAddr(...)` is configured correctly.
+
+### 2) Always getting default values
+
+- Check whether `unitID` is empty or unstable.
+- Verify the key exists in console (`layerKey`, `variantKey`, or `featureKey`).
+- Verify targeting conditions match user tags.
+
+### 3) Exposure data missing
+
+- Confirm `WithDisableReport(true)` is not enabled unintentionally.
+- If using manual mode (`WithAutomatic(false)`), ensure manual log API is called.
+- Confirm metrics plugin and sampling configuration are enabled in backend settings.
+
+### 4) Value type conversion failure
+
+- Use typed getters with defaults (`GetBoolWithDefault`, `GetInt64WithDefault`, etc.).
+- Verify value type in console matches code expectation.
+
+## FAQ
+
+### Should I use `GetExperiment` or `GetValueByVariantKey`?
+
+Use `GetExperiment` when your primary goal is to retrieve experiment assignment (recommended in code comments). Use `GetValueByVariantKey` when you want to read a parameter directly by globally unique key.
+
+### Is `GetRemoteConfig` still supported?
+
+`GetRemoteConfig` is kept for compatibility and remains supported. For new access paths, prefer `GetFeatureFlag` or `GetValueByVariantKey` based on your scenario.
+
+### Can I turn off exposure globally in test environments?
+
+Yes, use `WithDisableReport(true)` at `Init`.
+
+## API reference (exported core APIs)
+
+- Initialization: `Init`, `Release`, `RegisterProjectIDs`, `GetGlobalConfig`
+- User context: `NewUserContext`, `WithTags`, `WithTagKV`, `WithDecisionID`, `WithNewUnitID`, `WithNewDecisionID`, `WithExpandedData`
+- Evaluation: `GetExperiment`, `GetExperiments`, `GetFeatureFlag`, `GetValueByVariantKey`, `GetAllRemoteConfigs`, `GetRemoteConfig`
+- Manual exposure: `LogExperimentExposure`, `LogExperimentsExposure`, `LogFeatureFlagExposure`, `LogRemoteConfigExposure`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,220 +1,316 @@
 # Go SDK
 
-## 支持的平台
+ABetterChoice Go SDK 用于服务端实验分流、Feature Flag 评估、远程配置读取和曝光上报。
 
-Golang SDK 支持以下平台：
+## 支持平台
 
 - Linux
-- MacOS
+- macOS
 - Windows
 
-## 快速开始
+## 前置条件
 
-如果你还没有项目，请先按照[文档](https://docs.abetterchoice.ai/guide/getting-started/create-project)创建一个 ABetterChoice 项目和若干实验。这一步可以暂时跳过，但后续章节会用到项目 ID 和实验层名。
+- Go 1.17+
+- 已在 ABetterChoice 控制台创建项目
+- `ProjectID` 和 `SecretKey`
+
+参考文档：
+- [创建项目](https://docs.abetterchoice.ai/guide/getting-started/create-project)
+- [创建实验](https://docs.abetterchoice.ai/guide/features/create-experiment)
+- [Feature Flags](https://docs.abetterchoice.ai/guide/features/feature-flags)
 
 ## 安装
 
-SDK 通过 `go get` 安装，需要 Go 1.17 或以上版本。
-
-```
-go get git.woa.com/tencent_abtest/open-source/abetterchoice-go-sdk
+```bash
+go get github.com/abetterchoice/go-sdk
 ```
 
-## SDK 初始化
-
-安装完成后需要先初始化。`Init` 接受三个参数：
-
-1. 第一个参数按 Go 惯例传 `context`。
-2. 第二个参数传一个或多个项目 ID。
-3. 第三个参数是 `InitOption`，用于灵活配置初始化项。目前必传的是 SecretKey，可以在控制台 setting 页的 API key 区域取到。
+## 快速开始（推荐）
 
 ```go
-// Package main ...
 package main
 
 import (
- "context"
- abc "git.woa.com/tencent_abtest/open-source/abetterchoice-go-sdk"
- "log"
+    "context"
+    "log"
+
+    abc "github.com/abetterchoice/go-sdk"
 )
 
-abc.Init(context.TODO(), []string{"{{.ProjectID}}"}, abc.WithSecretKey("{{.SecretKey}}"))
+func main() {
+    ctx := context.Background()
+    projectID := "YOUR_PROJECT_ID"
+    secretKey := "YOUR_SECRET_KEY"
+    unitID := "YOUR_UNIT_ID"
+
+    // 每个进程初始化一次
+    err := abc.Init(ctx, []string{projectID}, abc.WithSecretKey(secretKey))
+    if err != nil {
+        log.Fatalf("abc.Init failed: %v", err)
+    }
+    defer abc.Release()
+
+    // 构建用户上下文，后续评估复用
+    userCtx := abc.NewUserContext(unitID, abc.WithTagKV("region", "sea"))
+
+    // 1) 推荐：通过全局唯一参数 key 读取
+    value, err := userCtx.GetValueByVariantKey(ctx, projectID, "drop_rate")
+    if err != nil {
+        log.Printf("GetValueByVariantKey failed: %v", err)
+    } else {
+        dropRate := value.GetFloat64WithDefault(0.05)
+        log.Printf("drop_rate=%v", dropRate)
+    }
+
+    // 2) 按层读取实验
+    exp, err := userCtx.GetExperiment(ctx, projectID, "matchmaking_layer")
+    if err != nil {
+        log.Printf("GetExperiment failed: %v", err)
+    } else if exp != nil {
+        mmrWindow := exp.GetInt64WithDefault("mmr_window", 100)
+        log.Printf("mmr_window=%d", mmrWindow)
+    }
+
+    // 3) Feature Flag
+    ff, err := userCtx.GetFeatureFlag(ctx, projectID, "new_shop")
+    if err != nil {
+        log.Printf("GetFeatureFlag failed: %v", err)
+    } else if ff != nil && ff.MustGetBool() {
+        log.Printf("new_shop enabled")
+    }
+}
 ```
 
-*进阶：首次接入可跳过，按需再回看*
-`InitOption` 还提供其他初始化项，详细列表见 `InitOption` 实现。除上面的 SecretKey 之外，比较常用的是关闭曝光上报。默认情况下，调用 `GetExperiment` 时 SDK 会自动上报一次曝光（即记录某个实验单元命中实验）；某些场景下这会带来过多预期外的曝光，稀释实验结果。
-你可以在调用实验接口时不上报曝光，等到合适的时机再补上报。设置 `WithDisableReport(true)` 可以全局关闭自动曝光，也可以在单个接口调用上局部关闭，后文会展开。
+## API 选型建议
+
+| 场景 | API | 说明 |
+| --- | --- | --- |
+| 通过参数 key 读取远程参数 | `GetValueByVariantKey` | 业务代码不依赖层名，支持实验优先 + 配置回退。 |
+| 需要拿某个已知层的完整分流结果 | `GetExperiment` | 返回组信息及层内参数。 |
+| 需要项目下全部命中层 | `GetExperiments` | 适用于批量透传或诊断。 |
+| 需要项目下所有远程配置快照 | `GetAllRemoteConfigs` | 一次读取本地缓存中的全部远程配置键值。 |
+| 简单开关控制 | `GetFeatureFlag` | 布尔开关语义清晰，支持类型化读取。 |
+
+## 初始化与生命周期
+
+### `Init(ctx, projectIDList, opts...)`
+
+`Init` 会执行远程拉取与本地缓存初始化，建议在进程启动时调用一次。
+
+常用选项：
+
+- `WithSecretKey(secretKey)`（必填）
+- `WithEnvType(envType)`（可选，默认正式环境）
+- `WithDisableReport(true|false)`（可选，全局曝光开关）
+- `WithRegionCode(regionCode)`（可选，按区域拉取配置）
+- `WithRegisterCacheClient(...)` / `WithRegisterDMPClient(...)` / `WithRegisterMetricsPlugin(...)`（高级扩展）
+
+示例：
 
 ```go
-abc.Init(context.TODO(), []string{"{{.ProjectID}}"}, abc.WithSecretKey("{{.SecretKey}}"), abc.WithDisableReport(true))
+err := abc.Init(
+    context.Background(),
+    []string{"YOUR_PROJECT_ID"},
+    abc.WithSecretKey("YOUR_SECRET_KEY"),
+    abc.WithDisableReport(false),
+)
 ```
 
-*进阶：多区域接入*
-ABC 部署在多个区域，SDK 默认指向全局（NA）端点。如果你的项目部署在新加坡（SG）区域，请在 `Init` **之前** 注册 SG 端点，并使用该区域签发的 SecretKey。
+### `Release()`
+
+进程退出前调用 `Release()`，清理内存状态。
+
+## 用户上下文与属性
+
+通过 `NewUserContext(unitID, opts...)` 构建用户上下文。
+
+常见属性选项：
+
+- `WithTags(map[string][]string)`
+- `WithTagKV(key, value)`
+- `WithDecisionID(decisionID)`
+- `WithNewUnitID(newUnitID)` / `WithNewDecisionID(newDecisionID)`（迁移场景）
+- `WithExpandedData(map[string]string)`（补充曝光数据）
+
+示例：
 
 ```go
-import "git.woa.com/tencent_abtest/open-source/abetterchoice-go-sdk/env"
-
-_ = env.RegisterAddr(env.TypePrd, "https://openapi.sg.abetterchoice.ai")
-abc.Init(context.TODO(), []string{"{{.ProjectID}}"},
-    abc.WithEnvType(env.TypePrd),
-    abc.WithSecretKey("{{.SecretKey}}"))
+userCtx := abc.NewUserContext(
+    "player_1001",
+    abc.WithTagKV("channel", "appstore"),
+    abc.WithTagKV("server_id", "s1"),
+)
 ```
 
-## 获取 Feature Flag
+## 评估 API
 
-本节介绍如何获取 feature flag 的取值。如果尚未创建 feature flag，请先按[文档](https://docs.abetterchoice.ai/guide/features/feature-flags)创建一个。
-假设我们已在 `project_id` 项目下创建了名为 `new_feature_flag`、类型为 Boolean 的 feature flag，可以这样取值：
+### 获取 Feature Flag
 
 ```go
-abcUserContext, err := abc.NewUserContext("{{.UnitID}}")
-featureFlag, err = abcUserContext.GetFeatureFlag(context.TODO(), "project_id", "new_feature_flag")
-flagValue = featureFlag.MustGetBool()
+userCtx := abc.NewUserContext("{{.UnitID}}")
+featureFlag, err := userCtx.GetFeatureFlag(context.TODO(), "project_id", "new_feature_flag")
+if err == nil && featureFlag != nil {
+    flagValue := featureFlag.MustGetBool()
+    _ = flagValue
+}
 ```
 
-## 获取所有远程配置
+### 按层获取实验
 
-如果只想拿到某个项目下所有远程配置的快照——可以调用 `GetAllRemoteConfigs`。返回本地缓存中所有**非实验**远程配置 key 及其默认取值。
+```go
+userCtx := abc.NewUserContext("{{.UnitID}}")
+experiment, err := userCtx.GetExperiment(context.TODO(), "project_id", "abc_layer_name")
+if err == nil && experiment != nil {
+    shouldShowBanner := experiment.GetBoolWithDefault("should_show_banner", false)
+    _ = shouldShowBanner
+}
+```
+
+### 按参数 key 获取值（`GetValueByVariantKey`）
+
+`GetValueByVariantKey` 的解析顺序：
+
+1. 若参数 key 归属于一个或多个实验层，按“每层最早实验 ID”升序遍历；
+2. 返回第一个命中非默认组的层；
+3. 若没有命中非默认组，回退到配置读取路径（`GetRemoteConfig` 逻辑）。
+
+```go
+userCtx := abc.NewUserContext("{{.UnitID}}")
+result, err := userCtx.GetValueByVariantKey(context.TODO(), "project_id", "should_show_banner")
+if err == nil && result != nil {
+    shouldShowBanner := result.GetBoolWithDefault(false)
+    _ = shouldShowBanner
+
+    // 便于上报与排障：
+    // LayerKey / ExperimentKey / ExperimentID / GroupKey / VariantID / ConfigKey
+    _ = result.Detail
+}
+```
+
+### 获取项目下全部实验命中
+
+```go
+userCtx := abc.NewUserContext("{{.UnitID}}")
+experiments, err := userCtx.GetExperiments(context.TODO(), "project_id", abc.WithAutomatic(false))
+if err == nil && experiments != nil {
+    _ = experiments
+}
+```
+
+### 获取项目下全部远程配置
 
 ```go
 configs, err := abc.GetAllRemoteConfigs("project_id")
 if err == nil {
     for key, value := range configs {
-        log.Infof("%s = %s", key, value.String())
+        _ = key
+        _ = value.String()
     }
 }
 ```
 
-## 获取实验和上报曝光
+## 曝光策略
 
-本节介绍如何创建实验，并通过 SDK 提供的接口获取实验分流结果。
+默认情况下，实验/配置/Feature Flag 查询会自动上报曝光。
 
+如果你是提前拉取，只有真正展示时才希望上报，建议改为手动曝光。
 
-| 术语             | 含义                                                               |
-| -------------- | ---------------------------------------------------------------- |
-| UnitID         | 实验单元 ID，可以是用户 ID、Session ID 或机器 ID。SDK 会保证同一个 UnitID 始终落到同一个实验组。 |
-| Layer（层）       | 一个层通常代表你产品中可用于实验的 100% 流量，可被进一步切分给一个或多个实验，同层内实验流量互斥。             |
-| Experiment（实验） | 单个实验最多占用所在层 100% 的流量，会进一步包含两个或多个实验组。                             |
-| Group（组）       | 同一个实验中，单元会被分到两个或多个组（如对照组、实验组）做对比。                                |
-| Parameter（参数）  | 绑定在某一层上的取值，同层内不同实验可以共享同一组参数。                                     |
-
-
-### 1. 创建实验
-
-如果还没创建实验，请按照[创建实验文档](https://abetterchoice-test.woa.com/docs/create_an_experiment)在控制台创建一个。
-
-### 2. 获取实验分流
-
-假设第 1 步在项目 `project_id` 下创建了一个层名为 `abc_layer_name` 的实验，层内有一个名为 `should_show_banner` 的 Boolean 类型参数。注意基础版里层名默认就是实验名；如果在同一层下又创建了新实验，需要从实验页面读取层名。
-当前提供三种方式拿到指定 unit id 的分流结果，所有接口都需要先构造一个携带 unit id 的 `UserContext`。
+### API 级关闭自动曝光
 
 ```go
-abcUserContext, err := abc.NewUserContext("{{.UnitID}}")
-```
-
-#### a. 通过层 Key 获取实验
-
-第一种方式是按层 Key 获取实验分流，并用强类型 API 取层内参数。当层/实验内有多个参数时这种方式比较方便。同一层下有多个实验时，单元只会落到其中一个，因此该接口能自动返回正确结果。这种方式还有一个好处：废弃旧实验、在同一层下新建实验时业务代码不用改。
-
-```go
-experiment, err := abcUserContext.GetExperiment(context.TODO(), "project_id", "abc_layer_name")
-if err == nil {
-    shouldShowBanner := experiment.GetBoolWithDefault("should_show_banner", false)
+experiments, err := userCtx.GetExperiments(context.TODO(), "project_id", abc.WithAutomatic(false))
+if err == nil && experiments != nil {
+    _ = abc.LogExperimentsExposure(context.TODO(), "project_id", experiments)
 }
 ```
 
-#### b. 通过参数 Key 获取实验
+### 手动曝光 API
 
-这种方式和上面类似，区别在于不按层名查，而是按参数名查（参数名在同一项目下是唯一的）。后续如果支持把参数从一层迁到另一层（比如发车层），这个接口会很有用。
+- `LogExperimentExposure(ctx, projectID, experimentResult)`
+- `LogExperimentsExposure(ctx, projectID, experimentList)`
+- `LogFeatureFlagExposure(ctx, projectID, featureFlag)`
+- `LogRemoteConfigExposure(ctx, projectID, configResult)`
 
-当同一个参数 Key 被多个层暴露时，SDK 会按"每个层下最早创建的实验 ID（即该层最小的实验 ID）"给这些层排序，再依次判断：先返回第一个**人群命中且落在非默认组**的层，否则回落到第一个命中的默认组；多层命中不再报错。
-
-```go
-result, err := abcUserContext.GetValueByVariantKey(context.TODO(), "project_id", "should_show_banner")
-if err == nil {
-    shouldShowBanner := result.GetBoolWithDefault(false)
-    // result.Detail 同时带有 LayerKey / ExperimentKey / ExperimentID / GroupKey / VariantID，可用于上报。
-}
-```
-
-#### c. 获取项目下全部实验分流
-
-某些场景下需要一次性拿到一个项目下所有的实验分流结果，SDK 提供了批量接口，返回值是 “层名 -> 该层内 unit 命中的实验分流” 的 map。前面提到这种方式容易导致曝光稀释，使用时请谨慎。可以按需通过 opts 关掉自动曝光（如下例），后续再用曝光接口手动补报。
+### 全局关闭曝光
 
 ```go
-experiments, err := abcUserContext.GetExperiments(context.TODO(), "project_id", abc.WithAutomatic(false))
-```
-
-### 3. 上报曝光
-
-按上面方式获取分流时可以选择关闭自动曝光，避免稀释；之后在合适时机手动上报：
-
-```go
-abc.LogExperimentExposure(context.TODO(), "{{.ProjectID}}", experiment)
-```
-
-### 4. 完整代码示例
-
-完整代码示例
-
-```go
-// Package main TODO
-package main
-
-import (
-  "context"
-
-  abc "git.woa.com/tencent_abtest/open-source/abetterchoice-go-sdk"
-  "git.woa.com/tencent_abtest/open-source/abetterchoice-go-sdk/env"
-  "git.woa.com/tencent_abtest/open-source/abetterchoice-go-sdk/plugin/log"
+err := abc.Init(
+    context.Background(),
+    []string{"YOUR_PROJECT_ID"},
+    abc.WithSecretKey("YOUR_SECRET_KEY"),
+    abc.WithDisableReport(true),
 )
-
-func main() {
-  defer abc.Release()
-  projectID := "6666"
-  // 进程内只需初始化一次
-  err := abc.Init(context.TODO(), []string{projectID},
-  	abc.WithEnvType(env.TypePrd),
- 	abc.WithSecretKey("{{.SecretKey}}"))
-  if err != nil {
-    log.Errorf("Init fail:%v", err)
-    return
-  }
-
-  // 拉取项目下所有远程配置（不评估人群、不上报曝光）
-  configs, _ := abc.GetAllRemoteConfigs(projectID)
-  for k, v := range configs {
-    log.Infof("remote_config %s = %s", k, v.String())
-  }
-
-  abcUserContext := abc.NewUserContext("unitID_demo")
-
-  // a. 通过层 Key 拿实验，关掉自动曝光，后面手动上报
-  experiment, err := abcUserContext.GetExperiment(context.TODO(), projectID, "abc_layer_name", abc.WithAutomatic(false))
-  if err != nil {
-    log.Errorf("GetExperiment fail:%v", err)
-    return
-  }
-  log.Infof("should_show_banner=%v", experiment.GetBoolWithDefault("should_show_banner", false))
-  _ = abc.LogExperimentExposure(context.TODO(), projectID, experiment)
-
-  // b. 通过参数 Key 拿实验
-  if result, err := abcUserContext.GetValueByVariantKey(context.TODO(), projectID, "should_show_banner"); err == nil {
-    log.Infof("variant=%v layer=%s expID=%d",
-      result.GetBoolWithDefault(false), result.Detail.LayerKey, result.Detail.ExperimentID)
-  }
-
-  // c. 批量拿项目下所有实验
-  if experiments, err := abcUserContext.GetExperiments(context.TODO(), projectID, abc.WithAutomatic(false)); err == nil {
-    for layerKey := range experiments.Data {
-      log.Infof("hit layer=%s", layerKey)
-    }
-  }
-
-  // Feature flag
-  if featureFlag, err := abcUserContext.GetFeatureFlag(context.TODO(), projectID, "new_feature_flag"); err == nil {
-    log.Infof("the feature flag value is %v", featureFlag.MustGetBool())
-  }
-}
 ```
 
+## 高级选项
+
+### 实验选项
+
+可用于 `GetExperiment(s)` 和 `GetValueByVariantKey`：
+
+- `WithLayerKey(layerKey)` / `WithLayerKeyList(layerKeys)`
+- `WithSceneID(sceneID)` / `WithSceneIDList(sceneIDs)`
+- `WithAutomatic(isAutomatic)`
+- `WithIsPreparedDMPTag(isPreparedDMPTag)`
+- `WithIsDisableDMP(isDisableDMP)`
+
+### 配置选项
+
+配置 API 与实验选项共享同一类型，同时提供：
+
+- `WithIsPreparedDMPTagConfigOpt(...)`
+- `WithIsDisableDMPConfigOpt(...)`
+
+### 多项目注册
+
+初始化后可继续注册其他项目：
+
+```go
+err := abc.RegisterProjectIDs(context.Background(), []string{"PROJECT_B", "PROJECT_C"})
+```
+
+## 排查指南
+
+### 1) `Init` 失败
+
+- 检查 `SecretKey` 与 `ProjectID` 是否匹配。
+- 检查网络连通性。
+- 如果使用自定义环境地址，确认 `env.RegisterAddr(...)` 配置正确。
+
+### 2) 总是拿到默认值
+
+- 检查 `unitID` 是否为空或不稳定。
+- 检查 key 是否在控制台存在（`layerKey` / `variantKey` / `featureKey`）。
+- 检查用户 tags 是否满足受众条件。
+
+### 3) 没有曝光数据
+
+- 确认没有误开 `WithDisableReport(true)`。
+- 如果使用手动模式（`WithAutomatic(false)`），确认调用了手动曝光 API。
+- 确认后端指标插件与采样配置可用。
+
+### 4) 类型转换失败
+
+- 优先使用带默认值的 getter（如 `GetBoolWithDefault`、`GetInt64WithDefault`）。
+- 检查控制台参数类型是否与代码预期一致。
+
+## FAQ
+
+### `GetExperiment` 和 `GetValueByVariantKey` 怎么选？
+
+优先拿实验分流语义时，用 `GetExperiment`；优先按参数 key 读取值时，用 `GetValueByVariantKey`。
+
+### `GetRemoteConfig` 还支持吗？
+
+支持。它主要用于兼容历史逻辑；新接入建议按场景优先使用 `GetFeatureFlag` 或 `GetValueByVariantKey`。
+
+### 测试环境能否关闭曝光？
+
+可以，初始化时设置 `WithDisableReport(true)`。
+
+## API 参考（核心导出）
+
+- 初始化：`Init`, `Release`, `RegisterProjectIDs`, `GetGlobalConfig`
+- 用户上下文：`NewUserContext`, `WithTags`, `WithTagKV`, `WithDecisionID`, `WithNewUnitID`, `WithNewDecisionID`, `WithExpandedData`
+- 评估：`GetExperiment`, `GetExperiments`, `GetFeatureFlag`, `GetValueByVariantKey`, `GetAllRemoteConfigs`, `GetRemoteConfig`
+- 手动曝光：`LogExperimentExposure`, `LogExperimentsExposure`, `LogFeatureFlagExposure`, `LogRemoteConfigExposure`


### PR DESCRIPTION
Rewrite README_zh to match the new README structure and terminology, including GetAllRemoteConfigs, GetValueByVariantKey resolution order, and ValueResult.Detail usage guidance.